### PR TITLE
Update tile to provide logs in Ops Manager

### DIFF
--- a/pattern-1/bosh-release/jobs/wso2ei/templates/ctl.erb
+++ b/pattern-1/bosh-release/jobs/wso2ei/templates/ctl.erb
@@ -108,6 +108,9 @@ case $1 in
 
     ln -s ${NFS_SHARE_SERVER_DIR}/server $WSO2_EI_HOME/repository/deployment
 
+    # Create symbolic link for logging
+    ln -s $WSO2_EI_HOME/repository/logs/ ${log_dir}
+
     $WSO2_EI_HOME/bin/integrator.sh start
 
     # Sleep for a little while so the server comes up

--- a/pattern-2/bosh-release/jobs/wso2ei/templates/ctl.erb
+++ b/pattern-2/bosh-release/jobs/wso2ei/templates/ctl.erb
@@ -109,6 +109,9 @@ case $1 in
 
     ln -s ${NFS_SHARE_SERVER_DIR}/server $WSO2_EI_HOME/repository/deployment
 
+    # Create symbolic link for logging
+    ln -s $WSO2_EI_HOME/repository/logs/ ${log_dir}
+
     $WSO2_EI_HOME/bin/integrator.sh start
 
     # Sleep for a little while so the server comes up

--- a/pattern-2/bosh-release/jobs/wso2ei_analytics_dashboard/templates/ctl.erb
+++ b/pattern-2/bosh-release/jobs/wso2ei_analytics_dashboard/templates/ctl.erb
@@ -85,6 +85,9 @@ case $1 in
     # Here add any libraries your application needs:
     cp /var/vcap/packages/jdbcdrivers/* ${WSO2_EI_ANALYTICS_HOME}/wso2/analytics/lib/
 
+    # Create symbolic link for logging
+    ln -s $WSO2_EI_ANALYTICS_HOME/wso2/analytics/wso2/dashboard/logs/ ${log_dir}
+
     $WSO2_EI_ANALYTICS_HOME/wso2/analytics/bin/dashboard.sh start
 
     # Sleep for a little while so the server comes up

--- a/pattern-2/bosh-release/jobs/wso2ei_analytics_worker/templates/ctl.erb
+++ b/pattern-2/bosh-release/jobs/wso2ei_analytics_worker/templates/ctl.erb
@@ -85,6 +85,9 @@ case $1 in
     # Here add any libraries your application needs:
     cp /var/vcap/packages/jdbcdrivers/* ${WSO2_EI_ANALYTICS_HOME}/wso2/analytics/lib/
 
+    # Create symbolic link for logging
+    ln -s $WSO2_EI_ANALYTICS_HOME/wso2/analytics/wso2/worker/logs/ ${log_dir}
+
     $WSO2_EI_ANALYTICS_HOME/wso2/analytics/bin/worker.sh start
 
     # Sleep for a little while so the server comes up


### PR DESCRIPTION
## Purpose
> Resolves https://github.com/wso2/pivotal-cf-ei/issues/5

## Goals
> Provides the ability to download logs for each job through the tile in Ops Manager

## Test environment
> PCF Ops Manager v2.4-build.131